### PR TITLE
ci: Add permissions to the action amannn/action-semantic-pull-request

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v5.4.0
+      - uses: amannn/action-semantic-pull-request@v5.5.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   main:
+    permissions:
+      pull-requests: read
+      statuses: write
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +30,7 @@ jobs:
             ci
             chore
           # Configure that a scope must always be provided.
-          requireScope: false
+          requireScope: true
           # Configure additional validation for the subject based on a regex.
           # This example ensures the subject starts with an uppercase character.
           subjectPattern: ^[A-Z].+$


### PR DESCRIPTION
Does not let pass the action. [issue](https://github.com/amannn/action-semantic-pull-request/issues/249)