### PR TITLE
fix(terraform): Fix terraform:destroy

### DIFF
--- a/terraform/Taskfile.yml
+++ b/terraform/Taskfile.yml
@@ -238,9 +238,6 @@ tasks:
       Exucute terraform destroy could be dangerous
       Do you want to continue?
     preconditions:
-      - test -f terraform.tfstate
-      - test -d .terraform
-      - test -f .terraform.lock.hcl
       - *TASK_RUNTIME_VAR
     cmds:
       - >


### PR DESCRIPTION
Remove the next precondition tasks.
- test -f terraform.tfstate
- test -d .terraform
- test -f .terraform.lock.hcl

Encourage to use specific commands into the root project. This tasks serve as base.